### PR TITLE
fix timing issue in postinst

### DIFF
--- a/packaging/after-install.sh
+++ b/packaging/after-install.sh
@@ -4,7 +4,9 @@ getent group nagios > /dev/null || groupadd --system nagios
 useradd --system ncr --home /opt/ncr --groups nagios
 
 if [ -x /bin/systemctl ]; then
+	/bin/systemctl daemon-reload
 	/bin/systemctl start ncr.service
 elif [ -x /usr/sbin/service ]; then
+	/sbin/initctl reload-configuration
 	/usr/sbin/service ncr start
 fi

--- a/packaging/systemd/ncr.service
+++ b/packaging/systemd/ncr.service
@@ -5,5 +5,5 @@ After=network.target
 [Service]
 ExecStart=/opt/ncr/ncr --config /etc/ncr/ncr.yml
 KillMode=process
-Restart=on-failure
+Restart=always
 User=ncr


### PR DESCRIPTION
On slow hosts starting the service after placing the service files can cause trouble during installation

```
2017-03-15 14:34:54,824 WARNING [10.0.3@unregistered] hypernode.configmgmt: Result: failed => None
2017-03-15 14:35:01,638 ERROR [10.0.3@unregistered] hypernode.configmgmt: Result: failed => '/usr/bin/apt-get -y -o "Dpkg::Options::=--force-confdef" -o "Dpkg::Options::=--force-confold"   install 'ncr-upstart'' failed: start: Unknown job: ncr
dpkg: error processing ncr-upstart (--configure):
```